### PR TITLE
[Experimental] Coalesce/parse nested inline tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,7 +337,8 @@ function coalesceInlineHTML(ast) {
 
             // are there more html nodes directly after? if so, fold them into the current node
             if (index < siblings.length - 1 && siblings[index + 1].type === 'html') {
-                // further folding is needed
+                // create a new coalescer context
+                coalescer(siblings[index + 1], index + 1, siblings);
             }
 
             let i = index + 1;

--- a/index.spec.js
+++ b/index.spec.js
@@ -484,6 +484,19 @@ describe('markdown-to-jsx', () => {
             expect($element.children[0].children[0].textContent).toBe('Hello');
         });
 
+        it('processes markdown within nested inline HTML', () => {
+            const element = render(converter('<time><span>**Hello**</span></time>'));
+            const $element = dom(element);
+
+            // inline elements are always wrapped in a paragraph context
+            expect($element.tagName).toBe('P');
+
+            expect($element.children[0].tagName).toBe('TIME');
+            expect($element.children[0].children[0].tagName).toBe('SPAN');
+            expect($element.children[0].children[0].children[0].tagName).toBe('STRONG');
+            expect($element.children[0].children[0].children[0].textContent).toBe('Hello');
+        });
+
         it('processes attributes within inline HTML', () => {
             const element = render(converter('<time data-foo="bar">Hello</time>'));
             const $element = dom(element);


### PR DESCRIPTION
The compiler should now handle things like:

```html
<time><span>**Foo**</span></time>
```