### PR TITLE
Fix rendering of inline code tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -411,7 +411,7 @@ export default function markdownToJSX(markdown, {overrides = {}} = {}) {
 
         const key = index || '0';
 
-        if (ast.type === 'code') {
+        if (ast.type === 'code' && ast.value) {
             return (
                 <pre key={key}>
                     <code className={`lang-${ast.lang}`}>

--- a/index.spec.js
+++ b/index.spec.js
@@ -543,6 +543,16 @@ describe('markdown-to-jsx', () => {
             expect($element.children[0].tagName).toBe('STRONG');
             expect($element.children[0].textContent).toBe('Hello');
         });
+
+        it('renders inline <code> tags', () => {
+            const element = render(converter('Text and <code>**code**</code>'));
+            const $element = dom(element);
+
+            expect($element.tagName).toBe('P');
+            expect($element.children[0].tagName).toBe('CODE');
+            expect($element.children[0].children[0].tagName).toBe('STRONG');
+            expect($element.children[0].children[0].textContent).toBe('code');
+        });
     });
 
     describe('horizontal rules', () => {


### PR DESCRIPTION
This Markdown

```markdown
Text and <code>**code**</code>
```

renders with this error:

```
warning.js:36 Warning: validateDOMNesting(...): <pre> cannot appear as a descendant of <p>. See Markdown > p > ... > pre.
```